### PR TITLE
Add Travis CI status badge to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple class for laying out a collection of views with a convenient API, while leveraging the power of Auto Layout.
 
-[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![Build status](https://travis-ci.com/airbnb/AloeStackView.svg?branch=master)](https://travis-ci.com/airbnb/AloeStackView)
 
 #### Supports Swift 4.2
 


### PR DESCRIPTION
This change simply adds a status badge to the README file, to make it easier to see the current Travis CI build status.

cc: @fancox, @apang42 