### PR TITLE
Support for horizontal stack view

### DIFF
--- a/Example/AloeStackViewExample.xcodeproj/project.pbxproj
+++ b/Example/AloeStackViewExample.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		A74F70BB217155FC0054AA18 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74F70BA217155FC0054AA18 /* MainViewController.swift */; };
 		A74F70C0217155FE0054AA18 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A74F70BF217155FE0054AA18 /* Assets.xcassets */; };
 		A74F70C3217155FE0054AA18 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A74F70C1217155FE0054AA18 /* LaunchScreen.storyboard */; };
+		B8D4D41621A8C97C003055C0 /* HorizontalStackRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D4D41521A8C97C003055C0 /* HorizontalStackRowView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 		A74F70BA217155FC0054AA18 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		A74F70BF217155FE0054AA18 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A74F70C2217155FE0054AA18 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		B8D4D41521A8C97C003055C0 /* HorizontalStackRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalStackRowView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +82,7 @@
 			isa = PBXGroup;
 			children = (
 				A7497A922174725700BB692A /* SwitchRowView.swift */,
+				B8D4D41521A8C97C003055C0 /* HorizontalStackRowView.swift */,
 				A7497A9821755AD100BB692A /* ExpandingRowView.swift */,
 			);
 			path = Views;
@@ -204,6 +207,7 @@
 				A7497A9721747DD600BB692A /* PhotoViewController.swift in Sources */,
 				A74F70B9217155FC0054AA18 /* AppDelegate.swift in Sources */,
 				A7497A9921755AD100BB692A /* ExpandingRowView.swift in Sources */,
+				B8D4D41621A8C97C003055C0 /* HorizontalStackRowView.swift in Sources */,
 				A7497A932174725700BB692A /* SwitchRowView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/AloeStackViewExample/ViewControllers/MainViewController.swift
+++ b/Example/AloeStackViewExample/ViewControllers/MainViewController.swift
@@ -43,6 +43,7 @@ public class MainViewController: AloeStackViewController {
     setUpHiddenRows()
     setUpExpandingRowView()
     setUpPhotoRow()
+    setUpHorizontalStackRowView()
   }
 
   private func setUpDescriptionRow() {
@@ -137,4 +138,9 @@ public class MainViewController: AloeStackViewController {
     }
   }
 
+  private func setUpHorizontalStackRowView() {
+    let view = HorizontalStackRowView()
+    stackView.addRow(view)
+  }
+  
 }

--- a/Example/AloeStackViewExample/Views/HorizontalStackRowView.swift
+++ b/Example/AloeStackViewExample/Views/HorizontalStackRowView.swift
@@ -1,0 +1,44 @@
+// Created by ApptekStudios on 11/24/18.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import AloeStackView
+import UIKit
+
+public class HorizontalStackRowView: AloeStackView {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(withAxis: .horizontal)
+    setUpViews()
+  }
+
+  public required init(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private let labels: [UILabel] = (1...9).map { i in
+    let label = UILabel()
+    label.text = "Label #\(i)"
+    label.font = UIFont.preferredFont(forTextStyle: .body)
+    return label
+  }
+
+  private func setUpViews() {
+    labels.forEach { addRow($0) }
+  }
+  
+}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A simple class for laying out a collection of views with a convenient API, while
 
 ## Introduction
 
-`AloeStackView` is a class that allows a collection of views to be laid out in a vertical list. In a broad sense, it is similar
+`AloeStackView` is a class that allows a collection of views to be laid out in a vertical (or horizontal) list. In a broad sense, it is similar
 to `UITableView`, however its implementation is quite different and it makes a different set of trade-offs.
 
 We first started using `AloeStackView` at Airbnb in our iOS app in 2016. We have since used it to implement nearly
@@ -93,7 +93,10 @@ You can create an instance of `AloeStackView` quite easily in your code:
 ```swift
 import AloeStackView
 
-let stackView = AloeStackView()
+let stackView = AloeStackView() //Defaults to vertical layout
+
+// Or specify a horizontal layout:
+let stackView = AloeStackView(withAxis: .horizontal)
 ```
 
 `AloeStackView` is a `UIView` (specifically a `UIScrollView`), and thus can be used in the same way as any other
@@ -110,6 +113,8 @@ public class MyViewController: AloeStackViewController {
   public override func viewDidLoad() {
     super.viewDidLoad()
     stackView.addRow(...)
+    
+    //stackView.axis = .horizontal //Uncomment to use horizontal layout
   }
 
 }

--- a/Sources/AloeStackView/AloeStackView.swift
+++ b/Sources/AloeStackView/AloeStackView.swift
@@ -23,7 +23,8 @@ open class AloeStackView: UIScrollView {
 
   // MARK: Lifecycle
 
-  public init() {
+  public init(withAxis axis: NSLayoutConstraint.Axis = .vertical) {
+    self.axis = axis
     super.init(frame: .zero)
     setUpViews()
     setUpConstraints()
@@ -34,6 +35,17 @@ open class AloeStackView: UIScrollView {
   }
 
   // MARK: - Public
+    
+  // MARK: Axis for stackview
+  public var axis: NSLayoutConstraint.Axis {
+    didSet {
+      setConstraintsForAxis()
+      stackView.axis = axis
+      for case let cell as StackViewCell in stackView.arrangedSubviews {
+        cell.axis = axis
+      }
+    }
+  }
 
   // MARK: Adding and Removing Rows
 
@@ -296,10 +308,10 @@ open class AloeStackView: UIScrollView {
   /// The height of separators in the stack view.
   ///
   /// The default height is 1px.
-  open var separatorHeight: CGFloat = 1 / UIScreen.main.scale {
+  open var separatorThickness: CGFloat = 1 / UIScreen.main.scale {
     didSet {
-      for cell in stackView.arrangedSubviews {
-        (cell as? StackViewCell)?.separatorHeight = separatorHeight
+      for case let cell as StackViewCell in stackView.arrangedSubviews {
+        cell.separatorThickness = separatorThickness
       }
     }
   }
@@ -422,22 +434,39 @@ open class AloeStackView: UIScrollView {
 
   private func setUpStackView() {
     stackView.translatesAutoresizingMaskIntoConstraints = false
-    stackView.axis = .vertical
+    stackView.axis = axis
     addSubview(stackView)
   }
 
   private func setUpConstraints() {
     setUpStackViewConstraints()
+    setConstraintsForAxis()
   }
 
+  var heightConstraint: NSLayoutConstraint?
+  var widthConstraint: NSLayoutConstraint?
+  
   private func setUpStackViewConstraints() {
     NSLayoutConstraint.activate([
-      stackView.topAnchor.constraint(equalTo: topAnchor),
-      stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-      stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-      stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-      stackView.widthAnchor.constraint(equalTo: widthAnchor)
-    ])
+        stackView.topAnchor.constraint(equalTo: topAnchor),
+        stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+        stackView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    
+    heightConstraint = stackView.heightAnchor.constraint(equalTo: heightAnchor)
+    widthConstraint = stackView.widthAnchor.constraint(equalTo: widthAnchor)
+  }
+  
+  private func setConstraintsForAxis() {
+    switch axis {
+    case .horizontal:
+      heightConstraint?.isActive = true
+      widthConstraint?.isActive = false
+    case .vertical:
+      heightConstraint?.isActive = false
+      widthConstraint?.isActive = true
+    }
   }
 
   private func createCell(withContentView contentView: UIView) -> StackViewCell {
@@ -447,9 +476,10 @@ open class AloeStackView: UIScrollView {
     cell.rowHighlightColor = rowHighlightColor
     cell.rowInset = rowInset
     cell.separatorColor = separatorColor
-    cell.separatorHeight = separatorHeight
+    cell.separatorThickness = separatorThickness
     cell.separatorInset = separatorInset
     cell.shouldHideSeparator = hidesSeparatorsByDefault
+    cell.axis = axis
 
     configureCell(cell)
 

--- a/Sources/AloeStackView/AloeStackView.swift
+++ b/Sources/AloeStackView/AloeStackView.swift
@@ -408,7 +408,7 @@ open class AloeStackView: UIScrollView {
   /// properties of the cell, override `configureCell(_:)` and perform the customization there,
   /// rather than on the cell returned from this method.
   open func cellForRow(_ row: UIView) -> StackViewCell {
-    return StackViewCell(contentView: row)
+    return StackViewCell(contentView: row, withAxis: axis)
   }
 
   /// Allows subclasses to configure the properties of the given `StackViewCell`.
@@ -479,7 +479,6 @@ open class AloeStackView: UIScrollView {
     cell.separatorThickness = separatorThickness
     cell.separatorInset = separatorInset
     cell.shouldHideSeparator = hidesSeparatorsByDefault
-    cell.axis = axis
 
     configureCell(cell)
 

--- a/Sources/AloeStackView/Views/SeparatorView.swift
+++ b/Sources/AloeStackView/Views/SeparatorView.swift
@@ -29,13 +29,26 @@ internal final class SeparatorView: UIView {
   }
 
   // MARK: Internal
+    
+  internal var axis: NSLayoutConstraint.Axis = .vertical {
+    didSet { invalidateIntrinsicContentSize() }
+  }
 
   internal override var intrinsicContentSize: CGSize {
-    #if swift(>=4.2)
-    return CGSize(width: UIView.noIntrinsicMetric, height: height)
-    #else
-    return CGSize(width: UIViewNoIntrinsicMetric, height: height)
-    #endif
+    switch axis {
+    case .horizontal:
+      #if swift(>=4.2)
+      return CGSize(width: thickness, height: UIView.noIntrinsicMetric)
+      #else
+      return CGSize(width: thickness, height: UIViewNoIntrinsicMetric)
+      #endif
+    case .vertical:
+      #if swift(>=4.2)
+      return CGSize(width: UIView.noIntrinsicMetric, height: thickness)
+      #else
+      return CGSize(width: UIViewNoIntrinsicMetric, height: thickness)
+      #endif
+    }
   }
 
   internal var color: UIColor {
@@ -43,7 +56,7 @@ internal final class SeparatorView: UIView {
     set { backgroundColor = newValue }
   }
 
-  internal var height: CGFloat = 1 {
+  internal var thickness: CGFloat = 1 {
     didSet { invalidateIntrinsicContentSize() }
   }
 

--- a/Sources/AloeStackView/Views/StackViewCell.swift
+++ b/Sources/AloeStackView/Views/StackViewCell.swift
@@ -22,8 +22,9 @@ open class StackViewCell: UIView {
 
   // MARK: Lifecycle
 
-  public init(contentView: UIView) {
+  public init(contentView: UIView, withAxis axis: NSLayoutConstraint.Axis = .vertical) {
     self.contentView = contentView
+    self.axis = axis
 
     super.init(frame: .zero)
     translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
This PR implements an 'axis' property on AloeStackView to enable horizontal stacks. The axis can be specified when initiating the view using `init(withAxis:)`, or changed via the `axis` property at any point.

Addresses issue #13. We spotted the existing pull request #15, however needed to be able to change the axis of the stackview on the fly (in our particular use case we change it depending on the screen orientation)