### PR TITLE
Creister/check ishidden changed

### DIFF
--- a/Sources/AloeStackView/AloeStackView.swift
+++ b/Sources/AloeStackView/AloeStackView.swift
@@ -186,7 +186,7 @@ open class AloeStackView: UIScrollView {
   ///
   /// If `animated` is `true`, the change is animated.
   open func setRowHidden(_ row: UIView, isHidden: Bool, animated: Bool = false) {
-    guard let cell = row.superview as? StackViewCell else { return }
+    guard let cell = row.superview as? StackViewCell, cell.isHidden != isHidden else { return }
 
     if animated {
       UIView.animate(withDuration: 0.3) {

--- a/Tests/AloeStackViewTests/AloeStackViewTests.swift
+++ b/Tests/AloeStackViewTests/AloeStackViewTests.swift
@@ -21,4 +21,16 @@ final class AloeStackViewTests: XCTestCase {
   func test() {
   }
 
+  func testSetRowHiddenDuplicateCalls() {
+    let stackView = AloeStackView()
+    let row = UIView()
+    stackView.addRow(row)
+
+    stackView.setRowHidden(row, isHidden: true, animated: true)
+    stackView.setRowHidden(row, isHidden: true, animated: true)
+    stackView.setRowHidden(row, isHidden: false, animated: true)
+
+    XCTAssertFalse(stackView.isRowHidden(row))
+  }
+
 }


### PR DESCRIPTION
Hi, we found that multiple calls to hideRow (with `true`) can cause unhiding to fail, this is due to `isHidden` having to be called inside the animation  block. This PR simply checks that isHidden is changing to avoid multiple calls causing issues.