### PR TITLE
Rows Become Permanently Hidden

### DIFF
--- a/Sources/AloeStackView/AloeStackView.swift
+++ b/Sources/AloeStackView/AloeStackView.swift
@@ -189,6 +189,7 @@ open class AloeStackView: UIScrollView {
     guard let cell = row.superview as? StackViewCell, cell.isHidden != isHidden else { return }
 
     if animated {
+      cell.layoutIfNeeded()
       UIView.animate(withDuration: 0.3) {
         cell.isHidden = isHidden
         cell.layoutIfNeeded()


### PR DESCRIPTION
We have a stack view with a row whose hidden state is animated and dependent on user input in a text field meeting certain criteria.  As a result, setRowHidden() is called many times in relatively rapid succession with each keystroke.  We have seen many scenarios where a succession of setRowHidden(true) renders the row permanently hidden - setRowHidden(false) does nothing.  If animation is disabled this issue does not occur.

I believe this is due to overlapping layout operations inside the UIView.animate block of setRowHidden() when called multiple times.  My understanding of best practices and guidance from Apple is to call layoutIfNeeded() prior to the animation block to complete/flush any pending layout operations.  I have made this change and it resolves the issue.