### PR TITLE
Fix typo exposed in api by replacing seperator with separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ stackView.separatorInset = .zero
 As with `hidesSeparatorsByDefault`, this property only applies to new rows that are added. Rows already in the
 `AloeStackView` won't be affected.
 
-You can change the separator inset for existing rows with the `setSeperatorInset(forRow:)` and
-`setSeperatorInset(forRows:)` methods.
+You can change the separator inset for existing rows with the `setSeparatorInset(forRow:)` and
+`setSeparatorInset(forRows:)` methods.
 
 `AloeStackView` also provides properties for customizing the color and height of separators:
 

--- a/Sources/AloeStackView/AloeStackView.swift
+++ b/Sources/AloeStackView/AloeStackView.swift
@@ -314,15 +314,15 @@ open class AloeStackView: UIScrollView {
   /// Sets the separator inset for the given row to the `UIEdgeInsets` provided.
   ///
   /// Only left and right insets are honored.
-  open func setSeperatorInset(forRow row: UIView, inset: UIEdgeInsets) {
+  open func setSeparatorInset(forRow row: UIView, inset: UIEdgeInsets) {
     (row.superview as? StackViewCell)?.separatorInset = inset
   }
 
   /// Sets the separator inset for the given rows to the `UIEdgeInsets` provided.
   ///
   /// Only left and right insets are honored.
-  open func setSeperatorInset(forRows rows: [UIView], inset: UIEdgeInsets) {
-    rows.forEach { setSeperatorInset(forRow: $0, inset: inset) }
+  open func setSeparatorInset(forRows rows: [UIView], inset: UIEdgeInsets) {
+    rows.forEach { setSeparatorInset(forRow: $0, inset: inset) }
   }
 
   // MARK: Hiding and Showing Separators


### PR DESCRIPTION
Hello!

Just went through the source code of AloeStackView as I was reading it for documentation and found out a couple of spelling mistakes which are exposed in the api.

`seperator` was written instead of `separator`.