### PR TITLE
Fix example using the newly named separator function

### DIFF
--- a/Example/AloeStackViewExample/ViewControllers/MainViewController.swift
+++ b/Example/AloeStackViewExample/ViewControllers/MainViewController.swift
@@ -87,7 +87,7 @@ public class MainViewController: AloeStackViewController {
       right: 0)
 
     stackView.setInset(forRows: hiddenRows, inset: rowInset)
-    stackView.setSeperatorInset(forRows: Array(hiddenRows.dropLast()), inset: separatorInset)
+    stackView.setSeparatorInset(forRows: Array(hiddenRows.dropLast()), inset: separatorInset)
   }
 
   private func setUpExpandingRowView() {


### PR DESCRIPTION
Forgot to update the example in the previous pull request. This commit allows the Examples project to compile again.

Apologies for that.