### PR TITLE
Add the possibility to wrap the stack view within the superview's layout margins

### DIFF
--- a/Example/AloeStackViewExample.xcodeproj/project.pbxproj
+++ b/Example/AloeStackViewExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3EE7174D22045E54006E6F75 /* PreserveLayoutMarginsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE7174C22045E54006E6F75 /* PreserveLayoutMarginsViewController.swift */; };
 		A7497A9121746D9700BB692A /* AloeStackView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7497A9021746D9700BB692A /* AloeStackView.framework */; };
 		A7497A932174725700BB692A /* SwitchRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7497A922174725700BB692A /* SwitchRowView.swift */; };
 		A7497A9721747DD600BB692A /* PhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7497A9621747DD600BB692A /* PhotoViewController.swift */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3EE7174C22045E54006E6F75 /* PreserveLayoutMarginsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreserveLayoutMarginsViewController.swift; sourceTree = "<group>"; };
 		A7420FAB21715DF500F2A343 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A7497A9021746D9700BB692A /* AloeStackView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AloeStackView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A7497A922174725700BB692A /* SwitchRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchRowView.swift; sourceTree = "<group>"; };
@@ -47,6 +49,7 @@
 			children = (
 				A74F70BA217155FC0054AA18 /* MainViewController.swift */,
 				A7497A9621747DD600BB692A /* PhotoViewController.swift */,
+				3EE7174C22045E54006E6F75 /* PreserveLayoutMarginsViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -204,6 +207,7 @@
 				A7497A9721747DD600BB692A /* PhotoViewController.swift in Sources */,
 				A74F70B9217155FC0054AA18 /* AppDelegate.swift in Sources */,
 				A7497A9921755AD100BB692A /* ExpandingRowView.swift in Sources */,
+				3EE7174D22045E54006E6F75 /* PreserveLayoutMarginsViewController.swift in Sources */,
 				A7497A932174725700BB692A /* SwitchRowView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/AloeStackViewExample/ViewControllers/MainViewController.swift
+++ b/Example/AloeStackViewExample/ViewControllers/MainViewController.swift
@@ -43,6 +43,7 @@ public class MainViewController: AloeStackViewController {
     setUpHiddenRows()
     setUpExpandingRowView()
     setUpPhotoRow()
+    setUpPreserveLayoutMarginsRow()
   }
 
   private func setUpDescriptionRow() {
@@ -134,6 +135,21 @@ public class MainViewController: AloeStackViewController {
       guard let self = self else { return }
       let vc = PhotoViewController()
       self.navigationController?.pushViewController(vc, animated: true)
+    }
+  }
+
+  private func setUpPreserveLayoutMarginsRow() {
+    let label = UILabel()
+    label.font = UIFont.preferredFont(forTextStyle: .body)
+    label.numberOfLines = 0
+    label.text = "Tap here to view an AloeStackView constrained within its superview layout margins"
+    label.isUserInteractionEnabled = true
+    
+    stackView.addRow(label)
+    stackView.setTapHandler(forRow: label) { [weak self] _ in
+        guard let self = self else { return }
+        let vc = PreserveLayoutMarginsViewController()
+        self.navigationController?.pushViewController(vc, animated: true)
     }
   }
 

--- a/Example/AloeStackViewExample/ViewControllers/PreserveLayoutMarginsViewController.swift
+++ b/Example/AloeStackViewExample/ViewControllers/PreserveLayoutMarginsViewController.swift
@@ -1,30 +1,66 @@
-//
-//  PreserveLayoutMarginsViewController.swift
-//  AloeStackViewExample
-//
 //  Created by Alexander Bredy on 01/02/2019.
 //  Copyright © 2019 Airbnb, Inc. All rights reserved.
-//
 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import AloeStackView
 import UIKit
 
-class PreserveLayoutMarginsViewController: UIViewController {
+public class PreserveLayoutMarginsViewController: AloeStackViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+  // MARK: Public
 
-        // Do any additional setup after loading the view.
-    }
-    
+  public override func viewDidLoad() {
+    super.viewDidLoad()
+    setUpSelf()
+    setUpStackView()
+    setUpRows()
+  }
 
-    /*
-    // MARK: - Navigation
+  // MARK: Private
 
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
+  private func setUpSelf() {
+    title = "Preserve superview layout margins"
+  }
 
+  private func setUpStackView() {
+    // Setting this property to true will constrain the stack view content within the layout margins of the superview
+    stackView.preservesSuperviewLayoutMargins = true
+
+    // Setting separator and row insets on this screen will add additional margins to the ones set by the
+    // superview.
+    stackView.separatorInset = .zero
+    stackView.rowInset = .zero
+  }
+
+  private func setUpRows() {
+    setUpDescriptionRow()
+    setUpAnotherRow()
+  }
+
+  private func setUpDescriptionRow() {
+    let label = UILabel()
+    label.font = UIFont.preferredFont(forTextStyle: .body)
+    label.numberOfLines = 0
+    label.text = "The margins of the AloeStackView in this screen include the ones from the superview layout margins."
+    stackView.addRow(label)
+  }
+
+  private func setUpAnotherRow() {
+    let label = UILabel()
+    label.font = UIFont.preferredFont(forTextStyle: .body)
+    label.numberOfLines = 0
+    label.text = "Check out this ViewController on both iPhone and iPad to see the margins difference!"
+    stackView.addRow(label)
+  }
 }

--- a/Example/AloeStackViewExample/ViewControllers/PreserveLayoutMarginsViewController.swift
+++ b/Example/AloeStackViewExample/ViewControllers/PreserveLayoutMarginsViewController.swift
@@ -1,0 +1,30 @@
+//
+//  PreserveLayoutMarginsViewController.swift
+//  AloeStackViewExample
+//
+//  Created by Alexander Bredy on 01/02/2019.
+//  Copyright © 2019 Airbnb, Inc. All rights reserved.
+//
+
+import UIKit
+
+class PreserveLayoutMarginsViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Sources/AloeStackView/AloeStackView.swift
+++ b/Sources/AloeStackView/AloeStackView.swift
@@ -304,6 +304,17 @@ open class AloeStackView: UIScrollView {
     }
   }
 
+  /// Set whether the layout margins of the superview should be included
+  /// This comes in handy as iPhones and iPads can have different layout margins
+  /// and convenient as it automatically provide an inset to all the rows
+  /// without having to set it explicitely
+  open override var preservesSuperviewLayoutMargins: Bool {
+    didSet {
+        stackView.preservesSuperviewLayoutMargins = preservesSuperviewLayoutMargins
+        stackView.isLayoutMarginsRelativeArrangement = preservesSuperviewLayoutMargins
+    }
+  }
+
   /// Specifies the default inset of row separators.
   ///
   /// Only left and right insets are honored. This inset will be used for any new row that is added


### PR DESCRIPTION
This pull request adds the ability to AloeStackView to adapt its insets to the superview's layout margins.

Motivations:
- Avoid to explicitly set the default margin when we want to inherit from the superview margins
- Automatic support for universal apps (iPhone and iPad can have different layout margins)

An example ViewController has been added to showcase this. The screenshot below comes from that VC. The default insets are set to 0. The existing margin is the one that the superview defines.

<img src="https://user-images.githubusercontent.com/6131420/52121807-85b11380-2629-11e9-8cf9-ab54420bc258.png" width=300/>

