### PR TITLE
Improve touch and tap handling of cells

### DIFF
--- a/Sources/AloeStackView/Views/StackViewCell.swift
+++ b/Sources/AloeStackView/Views/StackViewCell.swift
@@ -98,8 +98,7 @@ open class StackViewCell: UIView {
 
   open override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
     super.touchesMoved(touches, with: event)
-    guard contentView.isUserInteractionEnabled else { return }
-    guard let touch = touches.first else { return }
+    guard contentView.isUserInteractionEnabled, let touch = touches.first else { return }
 
     let locationInSelf = touch.location(in: self)
 
@@ -221,15 +220,16 @@ open class StackViewCell: UIView {
 
 }
 
-
 extension StackViewCell: UIGestureRecognizerDelegate {
+
   public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
     guard let view = gestureRecognizer.view else { return false }
 
     let location = touch.location(in: view)
     let hitView = view.hitTest(location, with: nil)
 
-    // ensure UIControls get the touches instead of the tap gesture
+    // Ensure UIControls get the touches instead of the tap gesture.
     return !(hitView is UIControl)
   }
+
 }

--- a/Sources/AloeStackView/Views/StackViewCell.swift
+++ b/Sources/AloeStackView/Views/StackViewCell.swift
@@ -96,6 +96,19 @@ open class StackViewCell: UIView {
     }
   }
 
+  open override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+    super.touchesMoved(touches, with: event)
+    guard contentView.isUserInteractionEnabled else { return }
+    guard let touch = touches.first else { return }
+
+    let locationInSelf = touch.location(in: self)
+
+    if let contentView = contentView as? Highlightable, contentView.isHighlightable {
+      let isPointInsideCell = point(inside: locationInSelf, with: event)
+      contentView.setIsHighlighted(isPointInsideCell)
+    }
+  }
+
   open override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
     super.touchesCancelled(touches, with: event)
     guard contentView.isUserInteractionEnabled else { return }
@@ -186,6 +199,7 @@ open class StackViewCell: UIView {
 
   private func setUpTapGestureRecognizer() {
     tapGestureRecognizer.addTarget(self, action: #selector(handleTap(_:)))
+    tapGestureRecognizer.delegate = self
     addGestureRecognizer(tapGestureRecognizer)
     updateTapGestureRecognizerEnabled()
   }
@@ -205,4 +219,17 @@ open class StackViewCell: UIView {
     separatorTrailingConstraint?.constant = -separatorInset.right
   }
 
+}
+
+
+extension StackViewCell: UIGestureRecognizerDelegate {
+  public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+    guard let view = gestureRecognizer.view else { return false }
+
+    let location = touch.location(in: view)
+    let hitView = view.hitTest(location, with: nil)
+
+    // ensure UIControls get the touches instead of the tap gesture
+    return !(hitView is UIControl)
+  }
 }


### PR DESCRIPTION
- cell highlight state will change as the touch moves in and out of the cell
- UIControls within a cell content view will receive touches before the tap gesture

Addresses https://github.com/airbnb/AloeStackView/issues/54