### PR TITLE
[Travis-CI] Run tests with iOS 10 simulator to workaround CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_script:
   - bundle exec pod lib lint --verbose --fail-fast
   - carthage build --verbose --no-skip-current
 script:
-  - xcodebuild -project AloeStackView.xcodeproj -scheme AloeStackView -sdk iphonesimulator -destination "platform=iOS Simulator,OS=9.0,name=iPhone 6s" -configuration Debug -PBXBuildsContinueAfterErrors=0 SWIFT_VERSION=$SWIFT_VERSION build test
+  - xcodebuild -project AloeStackView.xcodeproj -scheme AloeStackView -sdk iphonesimulator -destination "platform=iOS Simulator,OS=10.0,name=iPhone 6s" -configuration Debug -PBXBuildsContinueAfterErrors=0 SWIFT_VERSION=$SWIFT_VERSION build test


### PR DESCRIPTION
`xcodebuild ` fails to load the test module when running tests on the iOS 9.* simulator on Xcode 10.2.1. (https://travis-ci.com/airbnb/AloeStackView/jobs/207879372)

This PR fixes travis CI test failures by changing the simulator test environment from iOS 9 to iOS 10.