### PR TITLE
Add row(at: index) & index(of: row) APIs

### DIFF
--- a/Sources/AloeStackView/AloeStackView.swift
+++ b/Sources/AloeStackView/AloeStackView.swift
@@ -176,6 +176,27 @@ open class AloeStackView: UIScrollView {
     return stackView.arrangedSubviews.contains(cell)
   }
 
+  /// Returns row at the specified index, `nil` if the index is incorrect.
+  open func row(at index: Int) -> UIView? {
+    guard index >= 0 && index < stackView.arrangedSubviews.count else {
+        return nil
+    }
+    if let cell = stackView.arrangedSubviews[index] as? StackViewCell {
+        return cell.contentView
+    }
+    return nil
+  }
+
+  /// Returns index of the specified row, `nil` if the row isn't found.
+  open func index(of row: UIView) -> Int? {
+    guard let cell = row.superview as? StackViewCell else { return nil }
+    #if swift(>=5.0)
+      return stackView.arrangedSubviews.firstIndex(of: cell)
+    #else
+      return stackView.arrangedSubviews.index(of: cell)
+    #endif
+  }
+
   // MARK: Hiding and Showing Rows
 
   /// Hides the given row, making it invisible.

--- a/Tests/AloeStackViewTests/AloeStackViewTests.swift
+++ b/Tests/AloeStackViewTests/AloeStackViewTests.swift
@@ -50,5 +50,29 @@ final class AloeStackViewTests: XCTestCase {
     XCTAssertTrue(stackView.firstRow === firstRow)
     XCTAssertTrue(stackView.lastRow === lastRow)
   }
+    
+  func testGettingRowByIndex() {
+    let stackView = AloeStackView()
+    let firstRow = UIView()
+    let middleRow = UILabel()
+    let lastRow = UIButton()
+    stackView.addRows([firstRow, middleRow, lastRow])
+    XCTAssertTrue(stackView.row(at: 0) === firstRow)
+    XCTAssertTrue(stackView.row(at: 1) === middleRow)
+    XCTAssertTrue(stackView.row(at: 3) === nil)
+    XCTAssertTrue(stackView.row(at: -1) === nil)
+  }
+
+  func testGettingIndexOfRow() {
+    let stackView = AloeStackView()
+    let firstRow = UIView()
+    let middleRow = UILabel()
+    let lastRow = UIButton()
+    let notIncludedRow = UISwitch()
+    stackView.addRows([firstRow, middleRow, lastRow])
+    XCTAssertTrue(stackView.index(of: firstRow) == 0)
+    XCTAssertTrue(stackView.index(of: lastRow) == 2)
+    XCTAssertTrue(stackView.index(of: notIncludedRow) == nil)
+  }
   
 }


### PR DESCRIPTION
Hi, thanks for this helpful control.

But I'm missing similar APIs that UITableView has:

<img width="328" alt="Screen Shot 2019-06-20 at 6 07 35 PM" src="https://user-images.githubusercontent.com/16039/59871365-1782a880-93a0-11e9-93c1-711f33931986.png">

Since in AloeStackView cells are mostly hidden behind the curtains and we mostly work with rows, so this APIs also work with rows.

The names I've modeled from UITableView Swift API, plus how we get an object from Array (using `of` instead of `for`) (like we'd say it in English)

### Use cases:

For example I can get an index of a tapped element:
```swift
stack.setTapHandler(forRow: view) { [weak self] in 
  if let index = self?.stack.index(of: $0) { self?.showDetails(for: index) }
}
```

or I can get some data from settings and then do some manipulation
```swift
stack.row(at: selectionIndex)?.doSomething()
```