### PR TITLE
Change StackViewCell to pass touches to UIControls correctly.

### DIFF
--- a/Sources/AloeStackView/Views/StackViewCell.swift
+++ b/Sources/AloeStackView/Views/StackViewCell.swift
@@ -226,10 +226,18 @@ extension StackViewCell: UIGestureRecognizerDelegate {
     guard let view = gestureRecognizer.view else { return false }
 
     let location = touch.location(in: view)
-    let hitView = view.hitTest(location, with: nil)
+    var hitView = view.hitTest(location, with: nil)
 
-    // Ensure UIControls get the touches instead of the tap gesture.
-    return !(hitView is UIControl)
+    // Traverse the chain of superviews looking for any UIControls.
+    while hitView != view && hitView != nil {
+      if hitView is UIControl {
+        // Ensure UIControls get the touches instead of the tap gesture.
+        return false
+      }
+      hitView = hitView?.superview
+    }
+
+    return true
   }
 
 }


### PR DESCRIPTION
This change fixes an additional edge case with PR #55. In the previous
implementation, StackViewCell would only pass touches to UIControls if the touch
occurred on the UIControl itself, not on any of its subviews.

This meant that UIControls such as UISwitch would not receive touches if the row
had a tap handler set on it.

This change addresses the issue by searching up the superview chain for any
parent UIControls before allowing the touches to go to the tap handler's gesture
recognizer.