### PR TITLE
Minor cleanups to the Example app and documentation.

### DIFF
--- a/AloeStackView.xcodeproj/project.pbxproj
+++ b/AloeStackView.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = A74F6EC7216D5CB40054AA18;
 			productRefGroup = A74F6ED2216D5CB50054AA18 /* Products */;

--- a/Example/AloeStackViewExample.xcodeproj/project.pbxproj
+++ b/Example/AloeStackViewExample.xcodeproj/project.pbxproj
@@ -7,7 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		A7497A9121746D9700BB692A /* AloeStackView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7497A9021746D9700BB692A /* AloeStackView.framework */; };
+		4D42E5BA22E499FE00D51F93 /* AloeStackView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7497A9021746D9700BB692A /* AloeStackView.framework */; };
+		4D42E5BB22E499FE00D51F93 /* AloeStackView.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A7497A9021746D9700BB692A /* AloeStackView.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A7497A932174725700BB692A /* SwitchRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7497A922174725700BB692A /* SwitchRowView.swift */; };
 		A7497A9721747DD600BB692A /* PhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7497A9621747DD600BB692A /* PhotoViewController.swift */; };
 		A7497A9921755AD100BB692A /* ExpandingRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7497A9821755AD100BB692A /* ExpandingRowView.swift */; };
@@ -16,6 +17,20 @@
 		A74F70C0217155FE0054AA18 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A74F70BF217155FE0054AA18 /* Assets.xcassets */; };
 		A74F70C3217155FE0054AA18 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A74F70C1217155FE0054AA18 /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		4D42E5BC22E499FE00D51F93 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4D42E5BB22E499FE00D51F93 /* AloeStackView.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		A7420FAB21715DF500F2A343 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -35,7 +50,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A7497A9121746D9700BB692A /* AloeStackView.framework in Frameworks */,
+				4D42E5BA22E499FE00D51F93 /* AloeStackView.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -140,6 +155,7 @@
 				A74F70B1217155FB0054AA18 /* Sources */,
 				A74F70B2217155FB0054AA18 /* Frameworks */,
 				A74F70B3217155FB0054AA18 /* Resources */,
+				4D42E5BC22E499FE00D51F93 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/Example/AloeStackViewExample/Views/ExpandingRowView.swift
+++ b/Example/AloeStackViewExample/Views/ExpandingRowView.swift
@@ -33,7 +33,7 @@ public class ExpandingRowView: UIStackView, Tappable, Highlightable {
   // MARK: Public
 
   public func didTapView() {
-    textLabel.text = (textLabel.text ?? "") + lines[nextLine]
+    textLabel.text = (textLabel.text ?? "") + "\n" + lines[nextLine]
     nextLine += 1
     if nextLine == lines.count {
       nextLine = 0
@@ -83,19 +83,19 @@ public class ExpandingRowView: UIStackView, Tappable, Highlightable {
 
   private let lines = [
     "Two households, both alike in dignity,",
-    "\nIn fair Verona, where we lay our scene,",
-    "\nFrom ancient grudge break to new mutiny,",
-    "\nWhere civil blood makes civil hands unclean.",
-    "\nFrom forth the fatal loins of these two foes",
-    "\nA pair of star-cross'd lovers take their life;",
-    "\nWhose misadventured piteous overthrows",
-    "\nDo with their death bury their parents' strife.",
-    "\nThe fearful passage of their death-mark'd love,",
-    "\nAnd the continuance of their parents' rage,",
-    "\nWhich, but their children's end, nought could remove,",
-    "\nIs now the two hours' traffic of our stage;",
-    "\nThe which if you with patient ears attend,",
-    "\nWhat here shall miss, our toil shall strive to mend."
+    "In fair Verona, where we lay our scene,",
+    "From ancient grudge break to new mutiny,",
+    "Where civil blood makes civil hands unclean.",
+    "From forth the fatal loins of these two foes",
+    "A pair of star-cross'd lovers take their life;",
+    "Whose misadventured piteous overthrows",
+    "Do with their death bury their parents' strife.",
+    "The fearful passage of their death-mark'd love,",
+    "And the continuance of their parents' rage,",
+    "Which, but their children's end, nought could remove,",
+    "Is now the two hours' traffic of our stage;",
+    "The which if you with patient ears attend,",
+    "What here shall miss, our toil shall strive to mend."
   ]
 
 }

--- a/Example/AloeStackViewExample/Views/SwitchRowView.swift
+++ b/Example/AloeStackViewExample/Views/SwitchRowView.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import AloeStackView
 import UIKit
 
 public class SwitchRowView: UIView {
@@ -73,6 +74,15 @@ public class SwitchRowView: UIView {
       switchView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -2),
       switchView.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -1)
     ])
+  }
+
+}
+
+extension SwitchRowView: Tappable {
+
+  public func didTapView() {
+    switchView.setOn(!switchView.isOn, animated: true)
+    switchView.sendActions(for: .valueChanged)
   }
 
 }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ automatically keeps the UI up-to-date.
 
 * Widely used and vetted in a highly-trafficked iOS app.
 
-* Small, easy-to-understand codebase (under 500 lines of code) with no external dependencies keeps binary size
+* Small, easy-to-understand codebase (under 600 lines of code) with no external dependencies keeps binary size
 increase to a minimum and makes code contributions and debugging painless.
 
 ## System Requirements


### PR DESCRIPTION
* Change SwitchRowView to conform to Tappable and toggle the switch when tapped,
  demonstrating use of the Tappable protocol.

* Fix a very minor issue with the expanding row demo with newline handling when
  the example content repeats.

* Fix the example app to embed the AloeStackView.framework correctly so that
  it's possible to run the Example app on a real device.

* Update README to reflect current codebase size.