### PR TITLE
Add support for horizontal stack views.

### DIFF
--- a/Example/AloeStackViewExample/ViewControllers/MainViewController.swift
+++ b/Example/AloeStackViewExample/ViewControllers/MainViewController.swift
@@ -42,6 +42,7 @@ public class MainViewController: AloeStackViewController {
     setUpSwitchRow()
     setUpHiddenRows()
     setUpExpandingRowView()
+    setUpHorizontalRow()
     setUpPhotoRow()
   }
 
@@ -93,6 +94,77 @@ public class MainViewController: AloeStackViewController {
   private func setUpExpandingRowView() {
     let expandingRow = ExpandingRowView()
     stackView.addRow(expandingRow)
+  }
+
+  private func setUpHorizontalRow() {
+    let titleLabel = UILabel()
+    titleLabel.font = UIFont.preferredFont(forTextStyle: .body)
+    titleLabel.numberOfLines = 0
+    titleLabel.text = "Use a horizontal layout"
+    stackView.addRow(titleLabel)
+    stackView.hideSeparator(forRow: titleLabel)
+    stackView.setInset(forRow: titleLabel, inset: UIEdgeInsets(
+      top: stackView.rowInset.top,
+      left: stackView.rowInset.left,
+      bottom: 4,
+      right: stackView.rowInset.right))
+
+    let captionLabel = UILabel()
+    captionLabel.font = UIFont.preferredFont(forTextStyle: .caption2)
+    captionLabel.textColor = .blue
+    captionLabel.numberOfLines = 0
+    captionLabel.text = "(Try scrolling horizontally!)"
+    stackView.addRow(captionLabel)
+    stackView.hideSeparator(forRow: captionLabel)
+    stackView.setInset(forRow: captionLabel, inset: UIEdgeInsets(
+      top: 0,
+      left: stackView.rowInset.left,
+      bottom: stackView.rowInset.bottom,
+      right: stackView.rowInset.right))
+
+    let horizontalStackView = AloeStackView()
+    horizontalStackView.axis = .horizontal
+    horizontalStackView.hidesSeparatorsByDefault = true
+    horizontalStackView.showsHorizontalScrollIndicator = false
+
+    horizontalStackView.contentInset = UIEdgeInsets(
+      top: 0,
+      left: stackView.rowInset.left / 2,
+      bottom: 0,
+      right: stackView.rowInset.right / 2)
+
+    horizontalStackView.rowInset = UIEdgeInsets(
+      top: stackView.rowInset.top,
+      left: stackView.rowInset.left / 2,
+      bottom: stackView.rowInset.bottom,
+      right: stackView.rowInset.right / 2)
+
+    horizontalStackView.heightAnchor.constraint(equalToConstant: 120).isActive = true
+
+    stackView.addRow(horizontalStackView)
+    stackView.setInset(forRow: horizontalStackView, inset: .zero)
+
+    guard let image = UIImage(named: "lobster-dog") else { return }
+
+    for imageNumber in 1...10 {
+      let imageView = UIImageView(image: image)
+      imageView.isUserInteractionEnabled = true
+      imageView.contentMode = .scaleAspectFit
+
+      let aspectRatio = image.size.height / image.size.width
+      imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: aspectRatio).isActive = true
+
+      horizontalStackView.addRow(imageView)
+
+      horizontalStackView.setTapHandler(forRow: imageView) { [weak self] _ in
+        let alert = UIAlertController(
+          title: "Tapped on image \(imageNumber)",
+          message: nil,
+          preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Dismiss", style: .default))
+        self?.present(alert, animated: true)
+      }
+    }
   }
 
   private func setUpPhotoRow() {

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ A simple class for laying out a collection of views with a convenient API, while
 
 ## Introduction
 
-`AloeStackView` is a class that allows a collection of views to be laid out in a vertical list. In a broad sense, it is similar
-to `UITableView`, however its implementation is quite different and it makes a different set of trade-offs.
+`AloeStackView` is a class that allows a collection of views to be laid out in a vertical or horizontal list. In a broad
+sense, it is similar to `UITableView`, however its implementation is quite different and it makes a different set of
+trade-offs.
 
 We first started using `AloeStackView` at Airbnb in our iOS app in 2016. We have since used it to implement nearly
 200 screens in the app. The use cases are quite varied: everything from settings screens, to forms for creating a new
@@ -124,7 +125,11 @@ public class MyViewController: AloeStackViewController {
 
 The API of `AloeStackView` generally deals with "rows". A row can be any `UIView` that you want to use in your UI.
 
-Rows are arranged in a vertical column, and each row stretches the full width of the `AloeStackView`.
+By default, rows are arranged in a vertical column, and each row stretches the full width of the `AloeStackView`.
+
+The `axis` property on `AloeStackView` can be used to change the orientation. When `axis` is set to `.horizontal`,
+rows are arranged next to each other, left-to-right, and the `AloeStackView` scrolls horizontally, with each row
+stretching the full height of the `AloeStackView`.
 
 To build a UI with `AloeStackView`, you generally begin by adding the rows that make up your UI:
 
@@ -248,17 +253,22 @@ stackView.separatorInset = .zero
 ```
 ![Add rows](Docs/Images/zero_separator_inset.png)
 
-As with `hidesSeparatorsByDefault`, this property only applies to new rows that are added. Rows already in the
-`AloeStackView` won't be affected.
+In vertical orientation, only the left and right properties of `separatorInset` are used.
+
+In horizontal orientation, separators are displayed vertically between rows. In this case, only the top and bottom
+properties of `separatorInset` are used, and they control the spacing on the top and bottom of separators.
+
+As with `hidesSeparatorsByDefault`, the `separatorInset` property only applies to new rows that are added.
+Rows already in the `AloeStackView` won't be affected.
 
 You can change the separator inset for existing rows with the `setSeparatorInset(forRow:)` and
 `setSeparatorInset(forRows:)` methods.
 
-`AloeStackView` also provides properties for customizing the color and height of separators:
+`AloeStackView` also provides properties for customizing the color and width (or thickness) of separators:
 
 ```swift
 stackView.separatorColor = .blue
-stackView.separatorHeight = 2
+stackView.separatorWidth = 2
 ```
 ![Add rows](Docs/Images/large_blue_separators.png)
 

--- a/Sources/AloeStackView/Views/SeparatorView.swift
+++ b/Sources/AloeStackView/Views/SeparatorView.swift
@@ -22,6 +22,7 @@ internal final class SeparatorView: UIView {
   internal init() {
     super.init(frame: .zero)
     translatesAutoresizingMaskIntoConstraints = false
+    setUpConstraints()
   }
 
   internal required init?(coder aDecoder: NSCoder) {
@@ -31,11 +32,7 @@ internal final class SeparatorView: UIView {
   // MARK: Internal
 
   internal override var intrinsicContentSize: CGSize {
-    #if swift(>=4.2)
-    return CGSize(width: UIView.noIntrinsicMetric, height: height)
-    #else
-    return CGSize(width: UIViewNoIntrinsicMetric, height: height)
-    #endif
+    return CGSize(width: width, height: width)
   }
 
   internal var color: UIColor {
@@ -43,8 +40,17 @@ internal final class SeparatorView: UIView {
     set { backgroundColor = newValue }
   }
 
-  internal var height: CGFloat = 1 {
+  internal var width: CGFloat = 1 {
     didSet { invalidateIntrinsicContentSize() }
+  }
+
+  // MARK: Private
+
+  private func setUpConstraints() {
+    setContentHuggingPriority(.defaultLow, for: .horizontal)
+    setContentHuggingPriority(.defaultLow, for: .vertical)
+    setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    setContentCompressionResistancePriority(.defaultLow, for: .vertical)
   }
 
 }

--- a/Sources/AloeStackView/Views/StackViewCell.swift
+++ b/Sources/AloeStackView/Views/StackViewCell.swift
@@ -41,7 +41,7 @@ open class StackViewCell: UIView {
   }
 
   // MARK: Open
-    
+
   open override var isHidden: Bool {
     didSet {
       guard isHidden != oldValue else { return }
@@ -52,9 +52,7 @@ open class StackViewCell: UIView {
   open var rowHighlightColor = UIColor(red: 217 / 255, green: 217 / 255, blue: 217 / 255, alpha: 1)
 
   open var rowBackgroundColor = UIColor.clear {
-    didSet {
-      backgroundColor = rowBackgroundColor
-    }
+    didSet { backgroundColor = rowBackgroundColor }
   }
 
   open var rowInset: UIEdgeInsets {
@@ -62,14 +60,27 @@ open class StackViewCell: UIView {
     set { layoutMargins = newValue }
   }
 
+  open var separatorAxis: NSLayoutConstraint.Axis = .horizontal {
+    didSet {
+      updateSeparatorAxisConstraints()
+      updateSeparatorInset()
+    }
+  }
+
   open var separatorColor: UIColor {
     get { return separatorView.color }
     set { separatorView.color = newValue }
   }
 
+  open var separatorWidth: CGFloat {
+    get { return separatorView.width }
+    set { separatorView.width = newValue }
+  }
+
+  /// Alias for `separatorWidth`. Maintained for backwards compatibility.
   open var separatorHeight: CGFloat {
-    get { return separatorView.height }
-    set { separatorView.height = newValue }
+    get { return separatorWidth }
+    set { separatorWidth = newValue }
   }
 
   open var separatorInset: UIEdgeInsets = .zero {
@@ -143,6 +154,8 @@ open class StackViewCell: UIView {
   private let separatorView = SeparatorView()
   private let tapGestureRecognizer = UITapGestureRecognizer()
 
+  private var separatorTopConstraint: NSLayoutConstraint?
+  private var separatorBottomConstraint: NSLayoutConstraint?
   private var separatorLeadingConstraint: NSLayoutConstraint?
   private var separatorTrailingConstraint: NSLayoutConstraint?
 
@@ -168,6 +181,7 @@ open class StackViewCell: UIView {
   private func setUpConstraints() {
     setUpContentViewConstraints()
     setUpSeparatorViewConstraints()
+    updateSeparatorAxisConstraints()
   }
 
   private func setUpContentViewConstraints() {
@@ -183,17 +197,10 @@ open class StackViewCell: UIView {
   }
 
   private func setUpSeparatorViewConstraints() {
-    let leadingConstraint = separatorView.leadingAnchor.constraint(equalTo: leadingAnchor)
-    let trailingConstraint = separatorView.trailingAnchor.constraint(equalTo: trailingAnchor)
-
-    NSLayoutConstraint.activate([
-      separatorView.bottomAnchor.constraint(equalTo: bottomAnchor),
-      leadingConstraint,
-      trailingConstraint
-    ])
-
-    separatorLeadingConstraint = leadingConstraint
-    separatorTrailingConstraint = trailingConstraint
+    separatorTopConstraint = separatorView.topAnchor.constraint(equalTo: topAnchor)
+    separatorBottomConstraint = separatorView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    separatorLeadingConstraint = separatorView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    separatorTrailingConstraint = separatorView.trailingAnchor.constraint(equalTo: trailingAnchor)
   }
 
   private func setUpTapGestureRecognizer() {
@@ -209,13 +216,22 @@ open class StackViewCell: UIView {
     tapHandler?(contentView)
   }
 
-  private func updateTapGestureRecognizerEnabled() {
-    tapGestureRecognizer.isEnabled = contentView is Tappable || tapHandler != nil
+  private func updateSeparatorAxisConstraints() {
+    separatorTopConstraint?.isActive = separatorAxis == .vertical
+    separatorBottomConstraint?.isActive = true
+    separatorLeadingConstraint?.isActive = separatorAxis == .horizontal
+    separatorTrailingConstraint?.isActive = true
   }
 
   private func updateSeparatorInset() {
+    separatorTopConstraint?.constant = separatorInset.top
+    separatorBottomConstraint?.constant = separatorAxis == .horizontal ? 0 : -separatorInset.bottom
     separatorLeadingConstraint?.constant = separatorInset.left
-    separatorTrailingConstraint?.constant = -separatorInset.right
+    separatorTrailingConstraint?.constant = separatorAxis == .vertical ? 0 : -separatorInset.right
+  }
+
+  private func updateTapGestureRecognizerEnabled() {
+    tapGestureRecognizer.isEnabled = contentView is Tappable || tapHandler != nil
   }
 
 }


### PR DESCRIPTION
This change adds the ability to change the `axis` of an
AloeStackView between vertical and horizontal directions. The
`axis` can be changed dynamically, and separators become vertical
when the `axis` is `.horizontal`.

This change combines and builds on the work of PRs #15 and #23, and
addresses issue #13.

Special thanks to @neobeppe and @apptekstudios for their proposals
for implementing this feature.