### PR TITLE
add a `dynamic library` product to swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,10 @@ let package = Package(
         .library(
             name: "AloeStackView", 
             targets: ["AloeStackView"]),
+        .library(
+            name: "AloeStackViewDynamic",
+            type: .dynamic,
+            targets: ["AloeStackView"]),
     ],
     dependencies: [],
     targets: [


### PR DESCRIPTION
Hello!

I want to be able to import the library as a dynamic library instead of static, which I'm unable to do currently since there is no `type` specified in the `Package.swift` product.

The only change in this PR is that I created another product `AloeStackViewDynamic` in `Package.swift` that set the library type to `.dynamic`. 